### PR TITLE
Security fix

### DIFF
--- a/cloudflare/src/wrap.c
+++ b/cloudflare/src/wrap.c
@@ -259,7 +259,7 @@ void check_if_parent()
         snprintf(procpath, (sizeof(procpath) - 1), "/proc/%d/exe", ppid);
         if (does_file_exist(procpath)
             && readlink(procpath, readlinkbuf, sizeof(readlinkbuf) - 1) > 0) {
-            if (readlinkbuf == strstr(readlinkbuf, "/usr/local/cpanel/cpanel")) 		{
+            if (readlinkbuf == strstr(readlinkbuf, "/usr/local/cpanel/cpanel")) {
                 cpanelisparent = 1;
             } else {
                 syslog(LOG_INFO, "cPWrapper run with a parent: %s\n", readlinkbuf);
@@ -269,8 +269,7 @@ void check_if_parent()
         snprintf(procpath, (sizeof(procpath) - 1), "/proc/%d/file", ppid);
         if (!cpanelisparent && does_file_exist(procpath)
             && readlink(procpath, readlinkbuf, sizeof(readlinkbuf) - 1) > 0) {
-            if (readlinkbuf == strstr(readlinkbuf, "/usr/local/cpanel/cpanel"))
-                {
+            if (readlinkbuf == strstr(readlinkbuf, "/usr/local/cpanel/cpanel")) {
                 cpanelisparent = 1;
             } else {
                 syslog(LOG_INFO, "cPWrapper run with a parent: %s\n", readlinkbuf);


### PR DESCRIPTION
Allowing Exim as a parent process leaves the hole open.
