### PR TITLE
Applying the 11.52 Cpanel::JSON fix to the Logger.pm built before, bu…

### DIFF
--- a/cloudflare/Cpanel/CloudFlare/Config.pm
+++ b/cloudflare/Cpanel/CloudFlare/Config.pm
@@ -61,7 +61,8 @@ use strict;
     }
 
     sub is_debug_mode {
-        return $data->{"debug"};
+        my $data = Cpanel::CloudFlare::Helper::__get_json_loadfile_function()->($cf_config_file);
+        return $data->{"debug"} ? $data->{"debug"} : 0;
     }
 }
 

--- a/cloudflare/Cpanel/CloudFlare/Logger.pm
+++ b/cloudflare/Cpanel/CloudFlare/Logger.pm
@@ -11,14 +11,6 @@ use strict;
 
 my $logger;
 
-use constant IS_DEBUG_MODE => Cpanel::CloudFlare::Config::is_debug_mode();
-
-## Data::Dumper is only needed within debug mode
-## Some hosts do not have this installed
-if (IS_DEBUG_MODE) {
-    use Data::Dumper;
-}
-
 sub new {
     my ($type, $args) = @_;
     my $self = {};
@@ -43,15 +35,6 @@ sub debug {
     if(Cpanel::CloudFlare::Config::is_debug_mode()) {
         $logger->info(@_);
     }
-}
-
-# Wrapping Dumper() so we dont have to worry about including it everywhere.
-sub dumper {
-    my $self = shift;
-    if(Cpanel::CloudFlare::Config::is_debug_mode()) {
-        return Dumper(@_);
-    }
-    return;
 }
 
 # Cpanel::Logger->error() doesn't exist yet.


### PR DESCRIPTION
…t merged after the 11.52 fix. Removing Data::Dumper for now since 11.52 doesn't allow the global debug check for the use include.   is a good subsitute.