### PR TITLE
gh-98 PI-676: Symlinking php to /usr/local/cpanel/3rdparty/php/56/lib…

### DIFF
--- a/cloudflare.install.sh
+++ b/cloudflare.install.sh
@@ -214,6 +214,12 @@ cp -r $SOURCE_DIR/vendor/* $INSTALL_DIR/3rdparty/php/54/lib/php/cloudflare/vendo
 install -d $INSTALL_DIR/3rdparty/php/54/lib/php/cloudflare/src
 cp -r $SOURCE_DIR/src/* $INSTALL_DIR/3rdparty/php/54/lib/php/cloudflare/src
 
+# cPanel 58 uses PHP 5.6, previous versions use 5.4
+if [ -d "$INSTALL_DIR/3rdparty/php/56/" ]; then
+    # Create sym link from php/54 to php/56
+    ln -s $INSTALL_DIR/3rdparty/php/54/lib/php/cloudflare/ $INSTALL_DIR/3rdparty/php/56/lib/php/
+fi
+
 # Register the plugin buttons with Cpanel
 /usr/local/cpanel/scripts/install_plugin $SOURCE_DIR/installers/cloudflare_simple.tar.bz2
 

--- a/cloudflare.uninstall.sh
+++ b/cloudflare.uninstall.sh
@@ -8,7 +8,13 @@ INSTALL_DIR="/usr/local/cpanel"
 
 rm -rf $INSTALL_DIR/base/frontend/paper_lantern/cloudflare
 rm -rf $INSTALL_DIR/bin/admin/CloudFlare
+
 rm -rf $INSTALL_DIR/3rdparty/php/54/lib/php/cloudflare
+
+# cPanel 58 uses PHP 5.6, previous versions use 5.4
+if [ -d "$INSTALL_DIR/3rdparty/php/56/" ]; then
+    unlink $INSTALL_DIR/3rdparty/php/56/lib/php/cloudflare
+fi
 
 rm -rf $INSTALL_DIR/Cpanel/API/CloudFlare.pm
 


### PR DESCRIPTION
…/php/cloudflare for cPanel 58

cPanel 58 upgraded PHP from 5.4 to 5.6, this PR supports both versions of PHP in case the user is running an older version.