### PR TITLE
Add cPanel plugin app_key implements

### DIFF
--- a/installers/cloudflare_simple/install.json
+++ b/installers/cloudflare_simple/install.json
@@ -6,6 +6,7 @@
         "order" : 1,
         "type" : "link",
         "id" : "cloudflare",
-        "uri" : "cloudflare/index.live.php"
+        "uri" : "cloudflare/index.live.php",
+        "implements" : "Cloudflare_Home"
     }
 ]


### PR DESCRIPTION
The cPanel Single Sign On [create_user_session](https://documentation.cpanel.net/display/DD/WHM+API+1+Functions+-+create_user_session) method allows you to use app_keys to log in directly to a specific cPanel application page link. 

The Cloudflare URL would be `frontend/paper_lantern/cloudflare/index.live.php` for the theme `paper_lantern`.

You can see the available app_key links for a user using [get_users_links](https://documentation.cpanel.net/display/DD/WHM+API+1+Functions+-+get_users_links) API. 

Via the terminal as the root user on a cPanel server:
```bash
whmapi1 get_users_links user=<username>
```

---

To implement this feature in the Cloudflare plugin, the app key should be passed in the plugin install.json file using the key "implements". 

```
[
    {
        ...
        "implements" : "Cloudflare_Home"
    }
]
```
See documentation [here](https://documentation.cpanel.net/display/DD/Guide+to+cPanel+Plugins+-+Add+Plugins+to+Version+11.44+and+Later), it's not very clear that this can be used on the link config, it only shows an example when adding groups.

You can see cPanels default applications app_keys here https://documentation.cpanel.net/display/DD/Guide+to+cPanel+Interface+Customization+-+Appkeys

---

This feature allows us to directly link in support tickets and our dashboard directly to the cPanel Cloudflare application page using single sign on.


```
whmapi1 create_user_session user=username service=cpaneld locale=fr app=Cloudflare_Home preferred_domain=example.com
```

