### PR TITLE
Update cloudflare.install.sh

### DIFF
--- a/cloudflare.install.sh
+++ b/cloudflare.install.sh
@@ -112,7 +112,8 @@ if [ "$LOCAL_FILE_PATH" = "" ]; then
     fi
 
     # Download and extract
-    DOWNLOAD_URL="https://github.com/cloudflare/CloudFlare-CPanel/archive/v$LATEST_VERSION.tar.gz"
+    #DOWNLOAD_URL="https://github.com/cloudflare/CloudFlare-CPanel/archive/v$LATEST_VERSION.tar.gz"
+    DOWNLOAD_URL="https://github.com/cloudflare/CloudFlare-CPanel/archive/refs/tags/v$LATEST_VERSION.tar.gz"
 
     if [ "$VERBOSE" = true ]; then
         echo "curl -sL $DOWNLOAD_URL | tar xfz -"


### PR DESCRIPTION
Wrong DOWNLOAD_URL causing:

the given path has multiple possibilities: #<Git::Ref:0x00007fa1bea2c738>, #<Git::Ref:0x00007fa1bea33330>

New Path:
DOWNLOAD_URL="https://github.com/cloudflare/CloudFlare-CPanel/archive/refs/tags/v$LATEST_VERSION.tar.gz"